### PR TITLE
Changing the content wrapper from a div into a main

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,9 +7,9 @@
 
     {% include sidebar.html %}
 
-    <div class="content container">
+    <main class="content container">
       {{ content }}
-    </div>
+    </main>
 
   </body>
 </html>


### PR DESCRIPTION
#5  This solves the "Document must have one main landmark" issues AXE discovered during automated testing.